### PR TITLE
Sets variable to lazy load

### DIFF
--- a/lib/negroku/tasks/unicorn.rb
+++ b/lib/negroku/tasks/unicorn.rb
@@ -17,12 +17,12 @@ set_default  :unicorn_bin, 'bin/unicorn'
 set_default  :unicorn_socket, fetch(:app_server_socket)
 
 # Defines where the unicorn pid will live.
-set_default  :unicorn_pid, File.join(current_path, "tmp", "pids", "unicorn.pid")
+set_default(:unicorn_pid) { File.join(current_path, "tmp", "pids", "unicorn.pid") }
 
 # Preload app for fast worker spawn
 set_default :unicorn_preload, true
 
-set_default :unicorn_config_path, "#{shared_path}/config"
+set_default(:unicorn_config_path) { "#{shared_path}/config" }
 
 # Unicorn
 #------------------------------------------------------------------------------


### PR DESCRIPTION
This prevent early evaluation of deploy_to and current_path
and helps defining deploy_to parts on stage files

This allows to do

``` ruby
set(:deploy_to) { "/home/#{user}/applications/#{application}_#{branch}" }
```
