### PR TITLE
Stop using sudo to create a new nginx site

### DIFF
--- a/lib/negroku/tasks/nginx.rb
+++ b/lib/negroku/tasks/nginx.rb
@@ -46,8 +46,8 @@ namespace :nginx do
     else
       template "nginx.erb", "/tmp/nginx.conf"
     end
-    run "#{sudo} mv /tmp/nginx.conf /etc/nginx/sites-available/#{fetch(:application)}"
-    run "#{sudo} ln -nfs /etc/nginx/sites-available/#{fetch(:application)} /etc/nginx/sites-enabled/#{fetch(:application)}"
+    run "mv /tmp/nginx.conf /etc/nginx/sites-available/#{fetch(:application)}"
+    run "ln -nfs /etc/nginx/sites-available/#{fetch(:application)} /etc/nginx/sites-enabled/#{fetch(:application)}"
     run "mkdir -p /home/#{fetch(:user)}/log"
     reload
   end


### PR DESCRIPTION
I think is better if we use standard UNIX directory permissions for these commands, and use the passwordless sudo only for the `service nginx [command]` command 
