### PR TITLE
Escapes strings when doing env add

### DIFF
--- a/lib/negroku/tasks/rbenv.rb
+++ b/lib/negroku/tasks/rbenv.rb
@@ -11,7 +11,11 @@ namespace :rbenv do
 
     desc "Add rbenv vars"
     task :add, :roles => lambda { rbenv_roles } do
-      run "if awk < #{shared_path}/.rbenv-vars -F= '{print $1}' | grep --quiet #{key}; then sed -i 's/^#{key}=.*/#{key}=#{value}/g' #{shared_path}/.rbenv-vars; else echo '#{key}=#{value}' >> #{shared_path}/.rbenv-vars; fi"
+      cmd = "if awk < #{shared_path}/.rbenv-vars -F= '{print $1}' | grep --quiet -w #{key}; then "
+      cmd += "sed -i 's/^#{key}=.*/#{key}=#{value.gsub("\/", "\\/")}/g' #{shared_path}/.rbenv-vars;"
+      cmd += "else echo '#{key}=#{value}' >> #{shared_path}/.rbenv-vars;"
+      cmd += "fi"
+      run cmd
     end
 
     after "deploy:finalize_update", "rbenv:vars:symlink"


### PR DESCRIPTION
It escapes the value to be saved and searches only
for full key names using grep -w

Closes #57
